### PR TITLE
Fix build.zig instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ const sdl = b.dependency("sdl", .{
     .optimize = optimize,
     .target = target,
 });
-exe.linkLibrary(sdl.artifact("SDL3"));
+exe.root_module.linkLibrary(sdl.artifact("SDL3"));
 ```
 
 Finally, you can use SDL's C API from Zig like this:


### PR DESCRIPTION
With zig 0.16 the linkLibrary is a method on the Module struct rather than the Step.Compiler struct.

This updates the instructions to be in line with some of the changes in PR #13.