### PR TITLE
Migrate Zig example to translate-c

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ When making a PR that adds support for a new target:
 * Modify `build.zig.zon` to point to the desired SDL version
 * If you get linker errors or missing headers relating to Wayland protocols on Linux, new Wayland protocols were added upstream. You can fix this by running `zig build wayland-scanner` with `wayland-scanner`.
 * If you get any other linker errors or missing files, sources were added or renamed upstream, and you need to update `src/sdl.zon`.
+* Check if any headers need to be added to to `src/sdl.h`, or alternatively, if the intentional absence of any headers from this file needs to be documented.
 
 ## SDL's Dependencies
 

--- a/README.md
+++ b/README.md
@@ -19,21 +19,34 @@ You can add SDL3 to your project like this by updating `build.zig.zon` from the 
 zig fetch --save <url-of-this-repo>
 ```
 
-And then you can add it to your `build.zig` like this:
+You'll then want to create a C header file, say `src/sdl3.h` like:
+```c
+#include <SDL3/SDL.h>
+```
+
+Next you can add the following to your `build.zig` file:
 ```zig
 const sdl = b.dependency("sdl", .{
     .optimize = optimize,
     .target = target,
 });
-exe.root_module.linkLibrary(sdl.artifact("SDL3"));
+const sdl3_lib = sdl.artifact("SDL3");
+
+const sdl3_h = b.addTranslateC(.{
+    .root_source_file = b.path("src/sdl3.h"),
+    .target = target,
+    .optimize = optimize,
+});
+sdl3_h.addSystemIncludePath(sdl3_lib.getEmittedIncludeTree());
+
+exe.root_module.linkLibrary(sdl3_lib);
+exe.root_module.addImport("sdl3_h", sdl3_h.createModule());
 ```
 
 Finally, you can use SDL's C API from Zig like this:
 ```zig
 const std = @import("std");
-const c = @cImport({
-    @cInclude("SDL3/SDL.h");
-});
+const c = @import("sdl3_h");
 if (!c.SDL_Init(c.SDL_INIT_VIDEO)) {
     std.debug.panic("SDL_Init failed: {s}\n", .{c.SDL_GetError()});
 }

--- a/README.md
+++ b/README.md
@@ -19,38 +19,23 @@ You can add SDL3 to your project like this by updating `build.zig.zon` from the 
 zig fetch --save <url-of-this-repo>
 ```
 
-You'll then want to create a C header file, say `src/sdl3.h` like:
-```c
-#include <SDL3/SDL.h>
-```
-
-Next you can add the following to your `build.zig` file:
+And then you can add it to your `build.zig` like this:
 ```zig
 const sdl = b.dependency("sdl", .{
     .optimize = optimize,
     .target = target,
 });
-const sdl3_lib = sdl.artifact("SDL3");
-
-const sdl3_h = b.addTranslateC(.{
-    .root_source_file = b.path("src/sdl3.h"),
-    .target = target,
-    .optimize = optimize,
-});
-sdl3_h.addSystemIncludePath(sdl3_lib.getEmittedIncludeTree());
-
-exe.root_module.linkLibrary(sdl3_lib);
-exe.root_module.addImport("sdl3_h", sdl3_h.createModule());
+exe.root_module.addImport("sdl3", sdl.module("sdl3"));
 ```
 
 Finally, you can use SDL's C API from Zig like this:
 ```zig
 const std = @import("std");
-const c = @import("sdl3_h");
-if (!c.SDL_Init(c.SDL_INIT_VIDEO)) {
-    std.debug.panic("SDL_Init failed: {s}\n", .{c.SDL_GetError()});
+const sdl = @import("sdl3");
+if (!sdl.SDL_Init(sdl.SDL_INIT_VIDEO)) {
+    std.debug.panic("SDL_Init failed: {s}\n", .{sdl.SDL_GetError()});
 }
-defer c.SDL_Quit();
+defer sdl.SDL_Quit();
 ```
 
 ## Example

--- a/build.zig
+++ b/build.zig
@@ -69,6 +69,7 @@ pub fn build(b: *std.Build) !void {
     // Set the include path
     lib.root_module.addIncludePath(upstream.path("include"));
     lib.root_module.addIncludePath(upstream.path("src"));
+    lib.root_module.addIncludePath(upstream.path("src/video/khronos"));
 
     // Compile the generic sources
     lib.root_module.addCSourceFiles(.{
@@ -118,11 +119,12 @@ pub fn build(b: *std.Build) !void {
 
     // Translate the SDL headers and export them as a Zig module
     const translate_c = b.addTranslateC(.{
-        .root_source_file = upstream.path("include/SDL3/SDL.h"),
+        .root_source_file = b.path("src/sdl.h"),
         .target = target,
         .optimize = optimize,
     });
     translate_c.addIncludePath(upstream.path("include"));
+    translate_c.addIncludePath(upstream.path("src/video/khronos"));
     const module = translate_c.addModule("sdl3");
     module.linkLibrary(lib);
 

--- a/build.zig
+++ b/build.zig
@@ -34,7 +34,7 @@ pub fn build(b: *std.Build) !void {
         ,
     ) orelse .static;
 
-    // Get the so version. This is the same as the SDL version, but the major version is elided
+    // Get the SO version. This is the same as the SDL version, but the major version is elided
     // since it's baked into the name. This mirrors the official build process.
     var sdl_so_version = comptime std.SemanticVersion.parse(build_zon.dependencies.sdl.version) catch unreachable;
     assert(sdl_so_version.major == 3);
@@ -116,13 +116,15 @@ pub fn build(b: *std.Build) !void {
     // Add the Wayland scanner step
     linux.addWaylandScannerStep(b);
 
-    // Translate the C header for the example
-    const sdl3_h = b.addTranslateC(.{
-        .root_source_file = b.path("src/sdl3.h"),
+    // Translate the SDL headers and export them as a Zig module
+    const translate_c = b.addTranslateC(.{
+        .root_source_file = upstream.path("include/SDL3/SDL.h"),
         .target = target,
         .optimize = optimize,
     });
-    sdl3_h.addSystemIncludePath(lib.getEmittedIncludeTree());
+    translate_c.addIncludePath(upstream.path("include"));
+    const module = translate_c.addModule("sdl3");
+    module.linkLibrary(lib);
 
     // Add the example
     const example = b.addExecutable(.{
@@ -133,8 +135,7 @@ pub fn build(b: *std.Build) !void {
             .optimize = optimize,
         }),
     });
-    example.root_module.linkLibrary(lib);
-    example.root_module.addImport("sdl3_h", sdl3_h.createModule());
+    example.root_module.addImport("sdl3", module);
 
     const build_example_step = b.step("example", "Build the example app");
     build_example_step.dependOn(&example.step);

--- a/build.zig
+++ b/build.zig
@@ -116,6 +116,14 @@ pub fn build(b: *std.Build) !void {
     // Add the Wayland scanner step
     linux.addWaylandScannerStep(b);
 
+    // Translate the C header for the example
+    const sdl3_h = b.addTranslateC(.{
+        .root_source_file = b.path("src/sdl3.h"),
+        .target = target,
+        .optimize = optimize,
+    });
+    sdl3_h.addSystemIncludePath(lib.getEmittedIncludeTree());
+
     // Add the example
     const example = b.addExecutable(.{
         .name = "example",
@@ -126,6 +134,7 @@ pub fn build(b: *std.Build) !void {
         }),
     });
     example.root_module.linkLibrary(lib);
+    example.root_module.addImport("sdl3_h", sdl3_h.createModule());
 
     const build_example_step = b.step("example", "Build the example app");
     build_example_step.dependOn(&example.step);

--- a/src/example.zig
+++ b/src/example.zig
@@ -1,7 +1,5 @@
 const std = @import("std");
-const c = @cImport({
-    @cInclude("SDL3/SDL.h");
-});
+const c = @import("sdl3_h");
 
 const Io = std.Io;
 

--- a/src/example.zig
+++ b/src/example.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const c = @import("sdl3_h");
+const sdl = @import("sdl3");
 
 const Io = std.Io;
 
@@ -8,54 +8,54 @@ pub fn main() void {
     const io = threaded_io.io();
 
     // Initialize SDL
-    if (!c.SDL_Init(c.SDL_INIT_VIDEO)) {
-        std.debug.panic("{s}", .{c.SDL_GetError()});
+    if (!sdl.SDL_Init(sdl.SDL_INIT_VIDEO)) {
+        std.debug.panic("{s}", .{sdl.SDL_GetError()});
     }
-    defer c.SDL_Quit();
+    defer sdl.SDL_Quit();
 
-    std.debug.print("video driver: {s}\n", .{c.SDL_GetCurrentVideoDriver() orelse @as([*c]const u8, "null")});
+    std.debug.print("video driver: {s}\n", .{sdl.SDL_GetCurrentVideoDriver() orelse @as([*c]const u8, "null")});
 
     // Create a window and renderer
-    var window: ?*c.SDL_Window = null;
-    var renderer: ?*c.SDL_Renderer = null;
-    if (!c.SDL_CreateWindowAndRenderer(
+    var window: ?*sdl.SDL_Window = null;
+    var renderer: ?*sdl.SDL_Renderer = null;
+    if (!sdl.SDL_CreateWindowAndRenderer(
         "example",
         960,
         540,
-        c.SDL_WINDOW_RESIZABLE | c.SDL_WINDOW_HIGH_PIXEL_DENSITY,
+        sdl.SDL_WINDOW_RESIZABLE | sdl.SDL_WINDOW_HIGH_PIXEL_DENSITY,
         &window,
         &renderer,
     )) {
-        std.debug.panic("{s}", .{c.SDL_GetError()});
+        std.debug.panic("{s}", .{sdl.SDL_GetError()});
     }
-    defer c.SDL_DestroyWindow(window);
-    defer c.SDL_DestroyRenderer(renderer);
+    defer sdl.SDL_DestroyWindow(window);
+    defer sdl.SDL_DestroyRenderer(renderer);
 
     // Main loop
     while (true) {
         // Poll events
-        var event: c.SDL_Event = undefined;
-        while (c.SDL_PollEvent(&event)) {
-            if (event.type == c.SDL_EVENT_QUIT) {
+        var event: sdl.SDL_Event = undefined;
+        while (sdl.SDL_PollEvent(&event)) {
+            if (event.type == sdl.SDL_EVENT_QUIT) {
                 std.process.cleanExit(io);
                 return;
             }
         }
 
         // Update the background color
-        const now = @as(f64, @floatFromInt(c.SDL_GetTicks())) / 1000.0;
+        const now = @as(f64, @floatFromInt(sdl.SDL_GetTicks())) / 1000.0;
         const r: f32 = @floatCast(0.5 + 0.5 * @sin(now));
         const g: f32 = @floatCast(0.5 + 0.5 * @sin(now + std.math.pi * 2 / 3.0));
         const b: f32 = @floatCast(0.5 + 0.5 * @sin(now + std.math.pi * 4 / 3.0));
 
-        if (!c.SDL_SetRenderDrawColorFloat(renderer, r, g, b, c.SDL_ALPHA_OPAQUE_FLOAT)) {
-            std.debug.panic("{s}", .{c.SDL_GetError()});
+        if (!sdl.SDL_SetRenderDrawColorFloat(renderer, r, g, b, sdl.SDL_ALPHA_OPAQUE_FLOAT)) {
+            std.debug.panic("{s}", .{sdl.SDL_GetError()});
         }
-        if (!c.SDL_RenderClear(renderer)) {
-            std.debug.panic("{s}", .{c.SDL_GetError()});
+        if (!sdl.SDL_RenderClear(renderer)) {
+            std.debug.panic("{s}", .{sdl.SDL_GetError()});
         }
-        if (!c.SDL_RenderPresent(renderer)) {
-            std.debug.panic("{s}", .{c.SDL_GetError()});
+        if (!sdl.SDL_RenderPresent(renderer)) {
+            std.debug.panic("{s}", .{sdl.SDL_GetError()});
         }
     }
 }

--- a/src/sdl.h
+++ b/src/sdl.h
@@ -1,0 +1,53 @@
+//! # SDL Headers
+//!
+//! This file provides headers for tranlsation by Translate C to generate a Zig module.
+//!
+//! Usage of this file is optional. If you need additional configuration, consider using the static
+//! library directly, or providing your own type definitions (e.g. by running Translate C yourself.)
+//!
+//! # Rationale
+//!
+//! Most SDL headers are provided by `SDL.h`, either directly or transitively. If this covered all
+//! functionality, we would simplify translate `SDL.h`. However, `SDL.h` leaves off some files.
+//!
+//! We could expose these additional headers via build options, but this would require excessive
+//! build configuration that would need to be kept in sync across dependencies that use the SDL
+//! package.
+//!
+//! Alternatively we could provide a separate Zig module for each additional header, but this would
+//! result in duplicated symbols across the modules since these headers include headers already
+//! provided by `SDL3/SDL.h`.
+//!
+//! These headers are not particularly large, and Zig modules are lazily evaluated anyway, so we've
+//! opted to just include everything here except where otherwise noted in "Skipped Headers."
+//!
+//! # Skipped Headers
+//!
+//! The following includes are *not* provided for the given reasons:
+//!
+//! `SDL3/SDL_opengles` is a very old fixed function version of OpenGL ES from 2003. We would
+//! need to supply `GLES/gl.h` ourselves for this to work. It is very unlikely that new code is
+//! depending on OpenGL ES1, if you need it I recommend calling Translate C yourself and providing
+//! `GLES/gl.h` yourself.
+//!
+//! `SDL3/SDL_main.h` is not provided since its functionality is only usable from C/C++, and the
+//! goal of this file is to generate a Zig module.
+//!
+//! If you find that any other headers are missing, file an issue. They should either be added, or
+//! the reason for their absence should be documented here. Note that headers not included directly
+//! by `SDL.h` may be included transitively.
+
+// Include the main SDL header, this header provides most other SDL headers.
+#include <SDL3/SDL.h>
+
+// This is not pulling in the full Vulkan API to every build. It's just pulling in a few functions
+// that can be called to load the API and integrate with SDL.
+#include <SDL3/SDL_vulkan.h>
+
+// These headers provide OpenGL, EGL, ES2, and related functionality for windowing system
+// integration. These do generate a number of function headers and typedefs that aren't necessary
+// when not using these APIs, but they are properly namespaced and Zig's lazy evaluation should take
+// care of them when unused.
+#include <SDL3/SDL_opengl.h>
+#include <SDL3/SDL_egl.h>
+#include <SDL3/SDL_opengles2.h>

--- a/src/sdl3.h
+++ b/src/sdl3.h
@@ -1,1 +1,0 @@
-#include <SDL3/SDL.h>

--- a/src/sdl3.h
+++ b/src/sdl3.h
@@ -1,0 +1,1 @@
+#include <SDL3/SDL.h>


### PR DESCRIPTION
This migrates the Zig example to use the new "translate-c" build system introduced in Zig 0.16 as per https://ziglang.org/download/0.16.0/release-notes.html#cImport-Moving-to-Build-System. This is needed since `@cImport` is now deprecated.